### PR TITLE
included QDataStream in order to avoid the compiler error

### DIFF
--- a/dicttool.cpp
+++ b/dicttool.cpp
@@ -1,5 +1,6 @@
 #include "dicttool.h"
 
+#include <QDataStream>
 #include <QDebug>
 #include <QDir>
 #include <QFile>


### PR DESCRIPTION
```
/Users/handrake/project/qyomi/dicttool.cpp:45: error: variable has incomplete type 'QDataStream'
        QDataStream in(&wordsIn);
                    ^

```
Original source code gave me this error in QT Creator, so I added the QDataStream include in dicttool.cpp.

From reading http://doc.qt.io/qt-5/qdatastream.html, it seems the inclusion is somewhat necessary.